### PR TITLE
Story 1.2: CLI Argument Parsing with Defaults

### DIFF
--- a/lln_explorer/lln_explorer.py
+++ b/lln_explorer/lln_explorer.py
@@ -8,10 +8,127 @@ A CLI tool for visualizing the Law of Large Numbers through:
 - Variance decay with theory overlay
 """
 
+import argparse
+import sys
+from pathlib import Path
+
+# Exit codes
+EXIT_SUCCESS = 0
+EXIT_INVALID_ARGS = 1
+EXIT_RUNTIME_ERROR = 2
+
+# Default values
+DEFAULT_DIST = "normal"
+DEFAULT_M = 100
+DEFAULT_N = 10000
+DEFAULT_EPS = 0.1
+DEFAULT_OUTPUT = "./output"
+
+# Supported distributions
+SUPPORTED_DISTRIBUTIONS = ["normal", "bernoulli", "exponential", "uniform"]
+
+
+def parse_args(args=None):
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        prog="lln_explorer",
+        description="Visualize the Law of Large Numbers through simulations",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--dist",
+        type=str,
+        default=DEFAULT_DIST,
+        choices=SUPPORTED_DISTRIBUTIONS,
+        help="Distribution to sample from",
+    )
+
+    parser.add_argument(
+        "--M",
+        type=int,
+        default=DEFAULT_M,
+        help="Number of sample paths (realizations)",
+    )
+
+    parser.add_argument(
+        "--N",
+        type=int,
+        default=DEFAULT_N,
+        help="Maximum sample size per path",
+    )
+
+    parser.add_argument(
+        "--eps",
+        type=float,
+        default=DEFAULT_EPS,
+        help="Epsilon threshold for deviation probability",
+    )
+
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=DEFAULT_OUTPUT,
+        help="Output directory for generated plots",
+    )
+
+    return parser.parse_args(args)
+
+
+def validate_args(args):
+    """Validate parsed arguments. Returns error message or None if valid."""
+    if args.M <= 0:
+        return f"Error: M must be positive, got {args.M}"
+
+    if args.N <= 0:
+        return f"Error: N must be positive, got {args.N}"
+
+    if args.eps <= 0:
+        return f"Error: eps must be positive, got {args.eps}"
+
+    if args.eps >= 1:
+        return f"Error: eps must be less than 1, got {args.eps}"
+
+    return None
+
+
+def ensure_output_dir(output_path):
+    """Create output directory if it doesn't exist."""
+    path = Path(output_path)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
 
 def main():
     """Main entry point."""
-    pass
+    try:
+        args = parse_args()
+    except SystemExit as e:
+        # argparse exits with code 2 for invalid arguments, normalize to 1
+        sys.exit(EXIT_INVALID_ARGS)
+
+    # Validate arguments
+    error = validate_args(args)
+    if error:
+        print(error, file=sys.stderr)
+        sys.exit(EXIT_INVALID_ARGS)
+
+    # Ensure output directory exists
+    try:
+        output_dir = ensure_output_dir(args.output)
+    except OSError as e:
+        print(f"Error: Cannot create output directory: {e}", file=sys.stderr)
+        sys.exit(EXIT_RUNTIME_ERROR)
+
+    # Print configuration (placeholder for actual simulation)
+    print(f"LLN Explorer Configuration:")
+    print(f"  Distribution: {args.dist}")
+    print(f"  Sample paths (M): {args.M}")
+    print(f"  Max samples (N): {args.N}")
+    print(f"  Epsilon: {args.eps}")
+    print(f"  Output directory: {output_dir.resolve()}")
+
+    sys.exit(EXIT_SUCCESS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds argparse CLI with all required arguments (--dist, --M, --N, --eps, --output)
- Implements sensible defaults: dist=normal, M=100, N=10000, eps=0.1, output=./output
- Validates arguments with fail-fast behavior and appropriate exit codes
- Auto-creates output directory if it doesn't exist

## Acceptance Criteria

- [x] `--help` shows all available options with descriptions
- [x] No arguments uses defaults (dist=normal, M=100, N=10000, eps=0.1, output=./output)
- [x] Custom arguments override defaults
- [x] Invalid arguments (e.g., --M -5) exit with code 1 and error message
- [x] Output directory created automatically if missing

## Test plan

- [x] `python3 lln_explorer.py --help` displays usage
- [x] `python3 lln_explorer.py` runs with defaults
- [x] `python3 lln_explorer.py --dist bernoulli --M 50 --N 5000 --eps 0.05 --output ./custom` uses custom values
- [x] `python3 lln_explorer.py --M -5` exits with code 1
- [x] Output directories are created automatically

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)